### PR TITLE
fix(tiny): fix cardlist scroll display

### DIFF
--- a/src/components/Candidate/Resume/Resume.scss
+++ b/src/components/Candidate/Resume/Resume.scss
@@ -26,7 +26,7 @@
     background: url(../../../temp/images/icon-no-doc.png) no-repeat center;
     background-size: 60px;
     display: flex;
-    align-items: end;
+    align-items: flex-end;
     justify-content: center;
   }
   &__no-resume-text {

--- a/src/components/VacanciesPage/VacanciesPage.scss
+++ b/src/components/VacanciesPage/VacanciesPage.scss
@@ -17,11 +17,11 @@
 
   &__scroll-wrap {
     position: absolute;
-    top: -34px;
+    top: -31px;
     right: -22px;
     left: -12px;
     bottom: -12px;
-    height: calc(100vh - 195px - 123px + 12px);
+    height: calc(100vh - 195px - 123px + 31px);
     display: flex;
     gap: 32px;
     overflow-x: hidden;
@@ -41,7 +41,7 @@
   }
 
   &__content {
-    margin-top: 34px;
+    margin-top: 32px;
     margin-left: 12px;
     margin-bottom: 12px;
     position: relative;


### PR DESCRIPTION
зона прокрутки слегка наезжала сверху на зону сабхедера и имела ненужный отступ в нижней части (хотя зона прокрутки должна упираться в самый них окна при любой высоте) - пофиксила.
также поправила небольшое ругательство eslint на код в candidate/resume