### PR TITLE
fix(tiny): add uiType Button prop for displaying secondary type from UI-kit

### DIFF
--- a/src/components/Shared/_variables.scss
+++ b/src/components/Shared/_variables.scss
@@ -12,6 +12,7 @@ $color-grey: #929393;
 $color-dark-grey: #595959;
 $color-error: #f53c14;
 $color-success: #10c44c;
+$color-disable: transparentize(#929393, 0.6);
 $color-bg-grey: #f2f2f2;
 $color-bg-red: #ffe6e0;
 $color-bg-green: #d1ffe1;

--- a/src/components/UI/Button/Button.jsx
+++ b/src/components/UI/Button/Button.jsx
@@ -7,7 +7,8 @@ import iconPlay from '../../../images/icons/icon-play.svg';
 import iconPlus from '../../../images/icons/icon-plus.svg';
 
 const Button = (props) => {
-  const { text, disabled, size, type, pic, onClick, addBtnClass } = props;
+  const { text, disabled, size, uiType, type, pic, onClick, addBtnClass } =
+    props;
 
   // Если передали play или plus, то отображаем эти иконки, иначе иконки не будет
   let buttonIcon = null;
@@ -35,6 +36,7 @@ const Button = (props) => {
         'button',
         size === 'flexible' && 'button_size_flexible',
         size === 'small' && 'button_size_small',
+        uiType === 'main' ? 'button_ui-type_main' : 'button_ui-type_secondary',
         { [addBtnClass]: addBtnClass }
       )}
       type={type}
@@ -50,6 +52,7 @@ Button.propTypes = {
   text: PropTypes.string,
   disabled: PropTypes.bool,
   size: PropTypes.oneOf(['normal', 'small', 'flexible']),
+  uiType: PropTypes.oneOf(['main', 'secondary']),
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
   pic: PropTypes.oneOf(['play', 'plus', 'none']),
   onClick: PropTypes.func,
@@ -60,6 +63,7 @@ Button.defaultProps = {
   text: '',
   disabled: false,
   size: 'normal',
+  uiType: 'main',
   type: 'button',
   pic: 'plus',
   onClick: null,

--- a/src/components/UI/Button/Button.scss
+++ b/src/components/UI/Button/Button.scss
@@ -28,14 +28,34 @@
     padding: 6px 12px;
   }
 
-  &:hover {
-    background-color: $color-violet-hover;
+  &_ui-type_main {
+    &:hover {
+      background-color: $color-violet-hover;
+    }
+    &:active {
+      background-color: $color-violet-pressed;
+    }
+    &:disabled {
+      background-color: $color-disable;
+    }
   }
-  &:active {
-    background-color: $color-violet-pressed;
-  }
-  &:disabled {
-    background-color: $color-bg-grey;
+
+  &_ui-type_secondary {
+    background-color: transparent;
+    color: $color-violet-active;
+    border: 1px solid $color-violet-active;
+
+    &:hover {
+      background-color: $color-light-violet-hover;
+    }
+    &:active {
+      background-color: $color-light-violet-pressed;
+    }
+    &:disabled {
+      background-color: $color-bg-grey;
+      color: $color-disable;
+      border: 1px solid $color-disable;
+    }
   }
 
   &__pic {


### PR DESCRIPTION
все же решила сделать отдельным коммитом
добавила проп uiType - по дефолту отображается тип main (фиолетовая кнопка), но теперь можно настроить через проп также secondary тип из ui-kit.
скорректировала стили для состояния disabled (добавила новый цвет в variables)

визуал:
<img width="258" alt="image" src="https://github.com/recruitment-process/recruitment-process-frontend/assets/91292373/b2606732-06c7-43cf-9504-50882d8abf47">
